### PR TITLE
added bicubic and lanczos filtering for image.warp function.

### DIFF
--- a/generic/image.c
+++ b/generic/image.c
@@ -11,6 +11,10 @@
 #undef TAPI
 #define TAPI __declspec(dllimport)
 
+#ifndef M_PI
+#define M_PI    3.14159265358979323846
+#endif
+
 static void image_(Main_op_validate)( lua_State *L,  THTensor *Tsrc, THTensor *Tdst){
 
   long src_depth = 1;
@@ -683,7 +687,7 @@ int image_(Main_warp)(lua_State *L) {
   THTensor *dst = luaT_checkudata(L, 1, torch_Tensor);
   THTensor *src = luaT_checkudata(L, 2, torch_Tensor);
   THTensor *flowfield = luaT_checkudata(L, 3, torch_Tensor);
-  int bilinear = lua_toboolean(L, 4);
+  int mode = lua_tointeger(L, 4);
   int offset_mode = lua_toboolean(L, 5);
 
   // dims
@@ -702,7 +706,7 @@ int image_(Main_warp)(lua_State *L) {
   real *flow_data = THTensor_(data)(flowfield);
 
   // resample
-  long k,x,y;
+  long k,x,y,jj,v,u,i,j;
   for (y=0; y<height; y++) {
     for (x=0; x<width; x++) {
       // subpixel position:
@@ -716,40 +720,183 @@ int image_(Main_warp)(lua_State *L) {
       iy = MAX(iy,0); iy = MIN(iy,src_height-1);
 
       // bilinear?
-      if (bilinear) {
-        // 4 nearest neighbors:
-        long ix_nw = floor(ix);
-        long iy_nw = floor(iy);
-        long ix_ne = ix_nw + 1;
-        long iy_ne = iy_nw;
-        long ix_sw = ix_nw;
-        long iy_sw = iy_nw + 1;
-        long ix_se = ix_nw + 1;
-        long iy_se = iy_nw + 1;
+      switch (mode) {
+      case 1:  // Bilinear interpolation
+        {
+          // 4 nearest neighbors:
+          long ix_nw = floor(ix);
+          long iy_nw = floor(iy);
+          long ix_ne = ix_nw + 1;
+          long iy_ne = iy_nw;
+          long ix_sw = ix_nw;
+          long iy_sw = iy_nw + 1;
+          long ix_se = ix_nw + 1;
+          long iy_se = iy_nw + 1;
 
-        // get surfaces to each neighbor:
-        real nw = ((real)(ix_se-ix))*(iy_se-iy);
-        real ne = ((real)(ix-ix_sw))*(iy_sw-iy);
-        real sw = ((real)(ix_ne-ix))*(iy-iy_ne);
-        real se = ((real)(ix-ix_nw))*(iy-iy_nw);
+          // get surfaces to each neighbor:
+          real nw = ((real)(ix_se-ix))*(iy_se-iy);
+          real ne = ((real)(ix-ix_sw))*(iy_sw-iy);
+          real sw = ((real)(ix_ne-ix))*(iy-iy_ne);
+          real se = ((real)(ix-ix_nw))*(iy-iy_nw);
 
-        // weighted sum of neighbors:
-        for (k=0; k<channels; k++) {
-          dst_data[ k*os[0] + y*os[1] + x*os[2] ] = 
-              src_data[ k*is[0] +               iy_nw*is[1] +              ix_nw*is[2] ] * nw
-            + src_data[ k*is[0] +               iy_ne*is[1] + MIN(ix_ne,src_width-1)*is[2] ] * ne
-            + src_data[ k*is[0] + MIN(iy_sw,src_height-1)*is[1] +              ix_sw*is[2] ] * sw
-            + src_data[ k*is[0] + MIN(iy_se,src_height-1)*is[1] + MIN(ix_se,src_width-1)*is[2] ] * se;
+          // weighted sum of neighbors:
+          for (k=0; k<channels; k++) {
+            dst_data[ k*os[0] + y*os[1] + x*os[2] ] = 
+                src_data[ k*is[0] +               iy_nw*is[1] +              ix_nw*is[2] ] * nw
+              + src_data[ k*is[0] +               iy_ne*is[1] + MIN(ix_ne,src_width-1)*is[2] ] * ne
+              + src_data[ k*is[0] + MIN(iy_sw,src_height-1)*is[1] +              ix_sw*is[2] ] * sw
+              + src_data[ k*is[0] + MIN(iy_se,src_height-1)*is[1] + MIN(ix_se,src_width-1)*is[2] ] * se;
+          }
         }
-      } else {
-        // 1 nearest neighbor:
-        long ix_n = floor(ix+0.5);
-        long iy_n = floor(iy+0.5);
+	break;
+      case 0:  // Simple (i.e., nearest neighbor)
+        {
+          // 1 nearest neighbor:
+          long ix_n = floor(ix+0.5);
+          long iy_n = floor(iy+0.5);
 
-        // weighted sum of neighbors:
-        for (k=0; k<channels; k++) {
-          dst_data[ k*os[0] + y*os[1] + x*os[2] ] = src_data[ k*is[0] + iy_n*is[1] + ix_n*is[2] ];
+          // weighted sum of neighbors:
+          for (k=0; k<channels; k++) {
+            dst_data[ k*os[0] + y*os[1] + x*os[2] ] = src_data[ k*is[0] + iy_n*is[1] + ix_n*is[2] ];
+          }
         }
+        break;
+      case 2:  // Bicubic
+        {
+	  // Calculate fractional and integer components
+          long x_pix = floor(ix);
+          long y_pix = floor(iy);
+          real dx = ix - (real)x_pix;
+          real dy = iy - (real)y_pix;
+         
+          real C[4];
+          for (k=0; k<channels; k++) {
+            // Sweep by rows through the samples (to calculate final cubic coefs)
+            for (jj = 0; jj <= 3; jj++) {
+              v = y_pix - 1 + jj;
+              // We need to clamp all uv values to image border: hopefully 
+              // branch prediction and compiler reordering takes care of all
+              // the conditionals (since the branch probabilities are heavily 
+              // skewed).  Alternatively an inline "getPixelSafe" function would
+              // would be clearer here, but cannot be done with lua?
+              v = MAX(MIN((long)(src_height-1), v), 0);
+              long ofst = k * is[0] + v * is[1];  
+              u = x_pix;
+              u = MAX(MIN((long)(src_width-1), u), 0);
+              real a0 = src_data[ofst + u * is[2]];
+              u = x_pix - 1;
+              u = MAX(MIN((long)(src_width-1), u), 0);
+              real d0 = src_data[ofst + u * is[2]] - a0;
+              u = x_pix + 1;
+              u = MAX(MIN((long)(src_width-1), u), 0);
+              real d2 = src_data[ofst + u * is[2]] - a0;
+              u = x_pix + 2;
+              u = MAX(MIN((long)(src_width-1), u), 0); 
+              real d3 = src_data[ofst + u * is[2]] - a0;
+
+              // Note: there are mostly static casts, optimizer will take care of
+              // of it for us (prevents compiler warnings in new gcc)
+              real a1 =  -(real)1/(real)3*d0 + d2 -(real)1/(real)6*d3;
+              real a2 = (real)1/(real)2*d0 + (real)1/(real)2*d2;
+              real a3 = -(real)1/(real)6*d0 - (real)1/(real)2*d2 + 
+                (real)1/(real)6*d3;
+              C[jj] = a0 + dx * (a1 + dx * (a2 + a3 * dx));
+            }
+ 
+            real d0 = C[0]-C[1];
+            real d2 = C[2]-C[1];
+            real d3 = C[3]-C[1];
+            real a0 = C[1];
+            real a1 = -(real)1/(real)3*d0 + d2 - (real)1/(real)6*d3;
+            real a2 = (real)1/(real)2*d0 + (real)1/(real)2*d2;
+            real a3 = -(real)1/(real)6*d0 - (real)1/(real)2*d2 + 
+              (real)1/(real)6*d3;
+            real Cc = a0 + dy * (a1 + dy * (a2 + a3 * dy));
+
+            // I assume that since the image is stored as reals we don't have 
+            // to worry about clamping to min and max int (to prevent over or
+            // underflow)
+            dst_data[ k*os[0] + y*os[1] + x*os[2] ] = Cc;
+	  }  
+        }
+        break;
+      case 3:  // Lanczos
+	{
+          // Note: Lanczos can be made fast if the resampling period is 
+          // constant... and therefore the Lu, Lv can be cached and reused.
+          // However, unfortunately warp makes no assumptions about resampling 
+          // and so we need to perform the O(k^2) convolution on each pixel AND
+          // we have to re-calculate the kernel for every pixel.
+          // See wikipedia for more info.
+          // It is however an extremely good approximation to to full sinc
+          // interpolation (IIR) filter.
+          // Another note is that the version here has been optimized using
+          // pretty aggressive code flow and explicit inlining.  It might not
+          // be very readable (contact me, Jonathan Tompson, if it is not)
+
+          // Calculate fractional and integer components
+          long x_pix = floor(ix);
+          long y_pix = floor(iy);
+
+          // Precalculate the L(x) function evaluations in the u and v direction
+          const long rad = 3;  // This is a tunable parameter: 2 to 3 is OK
+          float Lu[2 * rad];  // L(x) for u direction
+          float Lv[2 * rad];  // L(x) for v direction
+          for (u=x_pix-rad+1, i=0; u<=x_pix+rad; u++, i++) {
+            float du = ix - (float)u;  // Lanczos kernel x value
+            du = du < 0 ? -du : du;  // prefer not to used std absf
+            if (du < 0.000001f) {  // TODO: Is there a real eps standard?
+              Lu[i] = 1;
+            } else if (du > (float)rad) {
+              Lu[i] = 0;
+            } else {
+              Lu[i] = ((float)rad * sin((float)M_PI * du) *       
+                sin((float)M_PI * du / (float)rad)) / 
+                ((float)(M_PI * M_PI) * du * du);
+            }
+          }
+          for (v=y_pix-rad+1, i=0; v<=y_pix+rad; v++, i++) {
+            float dv = iy - (float)v;  // Lanczos kernel x value
+            dv = dv < 0 ? -dv : dv;  // prefer not to used std absf
+            if (dv < 0.000001f) {  // TODO: Is there a real eps standard?
+              Lv[i] = 1;
+            } else if (dv > (float)rad) {
+              Lv[i] = 0;
+            } else {
+              Lv[i] = ((float)rad * sin((float)M_PI * dv) *
+                sin((float)M_PI * dv / (float)rad)) /
+                ((float)(M_PI * M_PI) * dv * dv);
+            }
+          }          
+          float sum_weights = 0;
+          for (u=0; u<2*rad; u++) {
+            for (v=0; v<2*rad; v++) {
+              sum_weights += (Lu[u] * Lv[v]); 
+            }
+          }
+
+          for (k=0; k<channels; k++) {
+            real result = 0;
+            for (u=x_pix-rad+1, i=0; u<=x_pix+rad; u++, i++) {
+              long curu = MAX(MIN((long)(src_width-1), u), 0);
+              for (v=y_pix-rad+1, j=0; v<=y_pix+rad; v++, j++) {
+                long curv = MAX(MIN((long)(src_height-1), v), 0);
+                real Suv = src_data[k * is[0] + curv * is[1] + curu * is[2]];
+                
+                real weight = (real)(Lu[i] * Lv[j]);
+                result += (Suv * weight);
+              }
+            }
+            // Normalize by the sum of the weights
+            result = result / (float)sum_weights;
+            
+            // Again,  I assume that since the image is stored as reals we 
+            // don't have to worry about clamping to min and max int (to 
+            // prevent over or underflow)
+            dst_data[ k*os[0] + y*os[1] + x*os[2] ] = result;
+          }
+        }
+        break;
       }
     }
   }

--- a/init.lua
+++ b/init.lua
@@ -542,15 +542,27 @@ local function warp(...)
                        'warp an image, according to a flow field', nil,
                        {type='torch.Tensor', help='input image (KxHxW)', req=true},
                        {type='torch.Tensor', help='(y,x) flow field (2xHxW)', req=true},
-                       {type='string', help='mode: bilinear | simple', default='bilinear'},
+                       {type='string', help='mode: lanczos | bicubic | bilinear | simple', default='bilinear'},
                        {type='string', help='offset mode (add (x,y) to flow field)', default=true},
                        '',
                        {type='torch.Tensor', help='destination', req=true},
                        {type='torch.Tensor', help='input image (KxHxW)', req=true},
                        {type='torch.Tensor', help='(y,x) flow field (2xHxW)', req=true},
-                       {type='string', help='mode: bilinear | simple', default='bilinear'},
+                       {type='string', help='mode: lanczos | bicubic | bilinear | simple', default='bilinear'},
                        {type='string', help='offset mode (add (x,y) to flow field)', default=true}))
       dok.error('incorrect arguments', 'image.warp')
+   end
+   -- This is a little messy, but convert mode string to an enum
+   if (mode == 'simple') then
+      mode = 0
+   elseif (mode == 'bilinear') then
+      mode = 1
+   elseif (mode == 'bicubic') then
+      mode = 2
+   elseif (mode == 'lanczos') then
+      mode = 3
+   else
+      dok.error('Incorrect arguments (mode is not lanczos | bicubic | bilinear | simple)!', 'image.warp')
    end
    local dim2 = false
    if src:nDimension() == 2 then
@@ -559,7 +571,8 @@ local function warp(...)
    end
    dst = dst or src.new()
    dst:resize(src:size(1), field:size(2), field:size(3))
-   src.image.warp(dst,src,field,((mode == 'bilinear') and true) or false, offset_mode)
+   
+   src.image.warp(dst,src,field,mode,offset_mode)
    if dim2 then
       dst = dst[1]
    end

--- a/test_warp.lua
+++ b/test_warp.lua
@@ -1,0 +1,121 @@
+require 'image'
+torch.setdefaulttensortype('torch.FloatTensor')
+torch.setnumthreads(16)
+
+im = image.lena()
+-- Subsample lena like crazy
+im = image.scale(im, im:size()[3] / 8, im:size()[2] / 8, 'bilinear')
+
+width = im:size()[3]  -- 512 / 8
+height = im:size()[2]  -- 512 / 8
+nchan = im:size()[1]  -- 3
+upscale = 8
+width_up = width * upscale
+height_up = height * upscale
+
+-- ******************************************
+-- COMPARE RESULTS OF UPSCALE (INTERPOLATION)
+-- ******************************************
+
+-- x/y grids
+grid_y = torch.ger( torch.linspace(-1,1,height_up), torch.ones(width_up) )
+grid_x = torch.ger( torch.ones(height_up), torch.linspace(-1,1,width_up) )
+
+flow = torch.FloatTensor()
+flow:resize(2,height_up,width_up)
+flow:zero()
+
+-- Apply scale
+flow_scale = torch.FloatTensor()
+flow_scale:resize(2,height_up,width_up)
+flow_scale[1] = grid_y
+flow_scale[2] = grid_x
+flow_scale[1]:add(1):mul(0.5) -- 0 to 1
+flow_scale[2]:add(1):mul(0.5) -- 0 to 1
+flow_scale[1]:mul(height)
+flow_scale[2]:mul(width)
+flow:add(flow_scale)
+
+t0 = sys.clock()
+im_simple = image.warp(im, flow, 'simple', false)
+t1 = sys.clock()
+print("Time simple = " .. (t1 - t0))  -- Not a robust measure (should average)
+image.display{image = im_simple, zoom = 1, legend = 'simple'}
+
+t0 = sys.clock()
+im_bilinear = image.warp(im, flow, 'bilinear', false)
+t1 = sys.clock()
+print("Time bilinear = " .. (t1 - t0))  -- Not a robust measure (should average)
+image.display{image = im_bilinear, zoom = 1, legend = 'bilinear'}
+
+t0 = sys.clock()
+im_bicubic = image.warp(im, flow, 'bicubic', false)
+t1 = sys.clock()
+print("Time bicubic = " .. (t1 - t0))  -- Not a robust measure (should average)
+image.display{image = im_bicubic, zoom = 1, legend = 'bicubic'}
+
+t0 = sys.clock()
+im_lanczos = image.warp(im, flow, 'lanczos', false)
+t1 = sys.clock()
+print("Time lanczos = " .. (t1 - t0))  -- Not a robust measure (should average)
+image.display{image = im_lanczos, zoom = 1, legend = 'lanczos'}
+
+-- *********************************************
+-- NOW TRY A ROTATION AT THE STANDARD RESOLUTION
+-- *********************************************
+
+im = image.lena()
+-- Subsample lena a little bit
+im = image.scale(im, im:size()[3] / 4, im:size()[2] / 4, 'bilinear')
+
+width = im:size()[3]  -- 512 / 4
+height = im:size()[2]  -- 512 / 4
+nchan = im:size()[1]  -- 3
+
+grid_y = torch.ger( torch.linspace(-1,1,height), torch.ones(width) )
+grid_x = torch.ger( torch.ones(height), torch.linspace(-1,1,width) )
+
+flow = torch.FloatTensor()
+flow:resize(2,height,width)
+flow:zero()
+
+-- Apply uniform scale
+flow_scale = torch.FloatTensor()
+flow_scale:resize(2,height,width)
+flow_scale[1] = grid_y
+flow_scale[2] = grid_x
+flow_scale[1]:add(1):mul(0.5) -- 0 to 1
+flow_scale[2]:add(1):mul(0.5) -- 0 to 1
+flow_scale[1]:mul(height)
+flow_scale[2]:mul(width)
+flow:add(flow_scale)
+
+flow_rot = torch.FloatTensor()
+flow_rot:resize(2,height,width)
+flow_rot[1] = grid_y * ((height-1)/2) * -1
+flow_rot[2] = grid_x * ((width-1)/2) * -1
+view = flow_rot:reshape(2,height*width)
+function rmat(deg)
+  local r = deg/180*math.pi
+  return torch.FloatTensor{{math.cos(r), -math.sin(r)}, {math.sin(r), math.cos(r)}}
+end
+rot_angle = 360/7  -- a nice non-integer value
+rotmat = rmat(rot_angle)
+flow_rotr = torch.mm(rotmat, view)
+flow_rot = flow_rot - flow_rotr:reshape( 2, height, width )
+flow:add(flow_rot)
+
+im_simple = image.warp(im, flow, 'simple', false)
+image.display{image = im_simple, zoom = 4, legend = 'simple'}
+
+im_bilinear = image.warp(im, flow, 'bilinear', false)
+image.display{image = im_bilinear, zoom = 4, legend = 'bilinear'}
+
+im_bicubic = image.warp(im, flow, 'bicubic', false)
+image.display{image = im_bicubic, zoom = 4, legend = 'bicubic'}
+
+im_lanczos = image.warp(im, flow, 'lanczos', false)
+image.display{image = im_lanczos, zoom = 4, legend = 'lanczos'}
+
+image.display{image = im, zoom = 4, legend = 'source image'}
+


### PR DESCRIPTION
I added bicubic and lanczos interpolation options to image.warp.  I wanted to perform high quality image rotations and upscaling... Bilinear interpolation tends to over filter, resulting in slightly blurry rotation images.  Lanczos is near perfect (but slow) and bicubic is a pretty good tradeoff between quality and speed.

I also added a test script (test_warp.lua) to show the difference between each of the methods, however lena is not a great test image for this sort of comparison.  The difference is much easier to see on synthetic images with sharp edges.

image.warp using bicubic iterpolation is about 2.3x slower than bilinear (but uses 16 samples per interpolation, instead of 4 so this is reasonable).

Lanczos interpolation is about 21x slower than bilinear (but it needs to perform a 7 x 7 non-separable convolution on each pixel... and even worse, the kernel is not constant and has to be re-computed on every pixel output).

Let me know if you have any questions / issues...
