### PR TITLE
Update to gaussian and laplacian functions

### DIFF
--- a/generic/image.c
+++ b/generic/image.c
@@ -905,6 +905,58 @@ int image_(Main_warp)(lua_State *L) {
   return 0;
 }
 
+int image_(Main_gaussian)(lua_State *L) {
+  THTensor *dst = luaT_checkudata(L, 1, torch_Tensor);
+  long width = dst->size[1];
+  long height = dst->size[0];
+  long *os = dst->stride;
+
+  real *dst_data = THTensor_(data)(dst);
+
+  real amplitude = (real)lua_tonumber(L, 2);
+  int normalize = (int)lua_toboolean(L, 3);
+  real sigma_u = (real)lua_tonumber(L, 4);
+  real sigma_v = (real)lua_tonumber(L, 5);
+  real mean_u = (real)lua_tonumber(L, 6) * (real)width + (real)0.5;
+  real mean_v = (real)lua_tonumber(L, 7) * (real)height + (real)0.5;
+
+  // Precalculate 1/(sigma*size) for speed (for some stupid reason the pragma
+  // omp declaration prevents gcc from optimizing the inside loop on my macine:
+  // verified by checking the assembly output)
+  real over_sigmau = (real)1.0 / (sigma_u * (real)width);
+  real over_sigmav = (real)1.0 / (sigma_v * (real)height);
+
+  long v, u;
+  real du, dv;
+#pragma omp parallel for private(v, u, du, dv)
+  for (v = 0; v < height; v++) {
+    for (u = 0; u < width; u++) {
+      du = ((real)u + 1 - mean_u) * over_sigmau;
+      dv = ((real)v + 1 - mean_v) * over_sigmav;
+      dst_data[ v*os[0] + u*os[1] ] = amplitude * 
+        exp(-((du*du*0.5) + (dv*dv*0.5)));
+    }
+  }
+
+  if (normalize) {
+    real sum = 0;
+    // We could parallelize this, but it's more trouble than it's worth
+    for(v = 0; v < height; v++) {
+      for(u = 0; u < width; u++) {
+        sum += dst_data[ v*os[0] + u*os[1] ];
+      }
+    }
+    real one_over_sum = 1.0 / sum;
+#pragma omp parallel for private(v, u)
+    for(v = 0; v < height; v++) {
+      for(u = 0; u < width; u++) {
+        dst_data[ v*os[0] + u*os[1] ] *= one_over_sum;
+      }
+    }
+  }
+  return 0;
+}
+
 static const struct luaL_Reg image_(Main__) [] = {
   {"scaleSimple", image_(Main_scaleSimple)},
   {"scaleBilinear", image_(Main_scaleBilinear)},
@@ -917,6 +969,7 @@ static const struct luaL_Reg image_(Main__) [] = {
   {"rgb2hsl", image_(Main_rgb2hsl)},
   {"hsv2rgb", image_(Main_hsv2rgb)},
   {"hsl2rgb", image_(Main_hsl2rgb)},
+  {"gaussian", image_(Main_gaussian)},
   {NULL, NULL}
 };
 

--- a/init.lua
+++ b/init.lua
@@ -1425,24 +1425,11 @@ function image.gaussian(...)
       {arg='mean_horz', type='number', help='horizontal mean', default=0.5},
       {arg='mean_vert', type='number', help='vertical mean', default=0.5}
    )
-   
-   -- local vars
-   local center_x = mean_horz * width + 0.5
-   local center_y = mean_vert * height + 0.5
 
    -- generate kernel
    local gauss = torch.Tensor(height, width)
-   for i=1,height do
-      for j=1,width do
-         gauss[i][j] = amplitude * math.exp(-(math.pow((j-center_x)
-                                                    /(sigma_horz*width),2)/2 
-                                           + math.pow((i-center_y)
-                                                   /(sigma_vert*height),2)/2))
-      end
-   end
-   if normalize then
-      gauss:div(gauss:sum())
-   end
+   gauss.image.gaussian(gauss, amplitude, normalize, sigma_horz, sigma_vert, mean_horz, mean_vert)
+   
    return gauss
 end
 

--- a/test_gaussian.lua
+++ b/test_gaussian.lua
@@ -1,0 +1,132 @@
+require 'image'
+
+-- Just create 2 gaussians images/kernels: 
+-- - one using code copy and pasted from the old
+-- - one using the c-based gaussian function
+-- This test is not particularly rigorous, but the function is very simple, so
+-- I'm not convinced it needs to be more complicated
+
+sigma_horz = 0.1 + math.random() * 0.3;  -- [0.1, 0.4] 
+sigma_vert = 0.1 + math.random() * 0.3;  -- [0.1, 0.4]
+mean_horz = 0.1 + math.random() * 0.8;  -- [0.1, 0.9] 
+mean_vert = 0.1 + math.random() * 0.8;  -- [0.1, 0.9]
+width = 640
+height = 480
+normalize = false
+amplitude = 10
+
+im1 = image.gaussian{amplitude=amplitude, 
+                     normalize=normalize, 
+                     width=width, 
+                     height=height, 
+                     sigma_horz=sigma_horz, 
+                     sigma_vert=sigma_vert, 
+                     mean_horz=mean_horz, 
+                     mean_vert=mean_vert}
+
+-- The old gaussian function, commit: 71670e1dcfcfe040aba5403c800a0d316987c2ed 
+function gaussian(...)
+   -- process args
+   local _, size, sigma, amplitude, normalize,
+   width, height, sigma_horz, sigma_vert, mean_horz, mean_vert = dok.unpack(
+      {...},
+      'image.gaussian',
+      'returns a 2D gaussian kernel',
+      {arg='size', type='number', help='kernel size (size x size)', default=3},
+      {arg='sigma', type='number', help='sigma (horizontal and vertical)', default=0.25},
+      {arg='amplitude', type='number', help='amplitute of the gaussian (max value)', default=1},
+      {arg='normalize', type='number', help='normalize kernel (exc Amplitude)', default=false},
+      {arg='width', type='number', help='kernel width', defaulta='size'},
+      {arg='height', type='number', help='kernel height', defaulta='size'},
+      {arg='sigma_horz', type='number', help='horizontal sigma', defaulta='sigma'},
+      {arg='sigma_vert', type='number', help='vertical sigma', defaulta='sigma'},
+      {arg='mean_horz', type='number', help='horizontal mean', default=0.5},
+      {arg='mean_vert', type='number', help='vertical mean', default=0.5}
+   )
+
+   -- local vars
+   local center_x = mean_horz * width + 0.5
+   local center_y = mean_vert * height + 0.5
+
+   -- generate kernel
+   local gauss = torch.Tensor(height, width)
+   for i=1,height do
+      for j=1,width do
+         gauss[i][j] = amplitude * math.exp(-(math.pow((j-center_x)
+                                                    /(sigma_horz*width),2)/2
+                                           + math.pow((i-center_y)
+                                                   /(sigma_vert*height),2)/2))
+      end
+   end
+   if normalize then
+      gauss:div(gauss:sum())
+   end
+   return gauss
+end
+
+im2 = gaussian{amplitude=amplitude,
+               normalize=normalize,
+               width=width,
+               height=height, 
+               sigma_horz=sigma_horz, 
+               sigma_vert=sigma_vert, 
+               mean_horz=mean_horz, 
+               mean_vert=mean_vert}
+
+-- make sure they're the same:
+delta = im1:clone()
+delta:mul(-1)
+delta:add(im2)
+
+print("norm(im1 - im2) = " .. delta:norm(2))
+
+-- try one with normalization to make sure that works as well:
+normalize = true
+im1 = image.gaussian{amplitude=amplitude,
+                     normalize=normalize,
+                     width=width,
+                     height=height, 
+                     sigma_horz=sigma_horz, 
+                     sigma_vert=sigma_vert, 
+                     mean_horz=mean_horz, 
+                     mean_vert=mean_vert}
+im2 = gaussian{amplitude=amplitude,
+               normalize=normalize,
+               width=width,
+               height=height,       
+               sigma_horz=sigma_horz,       
+               sigma_vert=sigma_vert,       
+               mean_horz=mean_horz,       
+               mean_vert=mean_vert}
+
+-- make sure they're the same:
+delta = im1:clone()
+delta:mul(-1)
+delta:add(im2)
+
+print("norm(im1 - im2) = " .. delta:norm(2) .. " (with normalization)")
+
+-- Now try profiling:
+num_repeats = 10
+time = sys.clock()
+for i=1,num_repeats do
+  im1 = image.gaussian{width=width, height=height}
+end
+time = sys.clock() - time
+print("c-based gaussian with omp time: " .. time)
+
+time = sys.clock()
+for i=1,num_repeats do
+  im1 = gaussian{width=width, height=height}
+end
+time = sys.clock() - time
+print("lua-based gaussian time: " .. time)
+
+  
+
+
+
+
+
+
+


### PR DESCRIPTION
- I added "mean_horz" and "mean_vert" input parameters to gaussian, gaussian1D and laplacian functions
- I wrote a c-based +openmp version of gaussian
- I verified that the new c-based gaussian gives the same result as the old code (although this test is admittedly a little precarious) within floating point precision

On my machine, creating 640x480 gaussian kernels (10 kernels in a loop):

c-based gaussian with omp time: 0.010269999998854 sec
lua-based gaussian time: 3.4788540000009 sec

creating 5x5 kernels (1000 in a loop):

c-based gaussian with omp time: 0.036453000007896 sec  
lua-based gaussian time: 0.046321000001626 sec

So, for small kernels there's almost no speedup (I think openmp thread spawn overhead is high), but my application needs to create a large number of large 2D gaussian kernels; so these commits help!
