### PR TITLE
Added a method to decompress a JPEG from a ByteTensor.  

### DIFF
--- a/tests/test_decompress_jpg.lua
+++ b/tests/test_decompress_jpg.lua
@@ -1,0 +1,62 @@
+require 'image'
+require 'paths'
+gm = require 'graphicsmagick'
+
+torch.setdefaulttensortype('torch.DoubleTensor')
+torch.setnumthreads(4)
+
+-- Create an instance of the test framework
+local mytester = torch.Tester()
+local precision = 1e-6
+local test = {}
+
+function test.CompareLoadAndDecompress()
+  -- This test breaks if someone removes lena from the repo
+  local imfile = '../lena.jpg'
+  if not paths.filep(imfile) then
+    error(imfile .. ' is missing!')
+  end
+  
+  -- Load lena directly from the filename
+  local img = image.loadJPG(imfile)
+  
+  -- Make sure the returned image width and height match the height and width
+  -- reported by graphicsmagick (just a sanity check)
+  local info = gm.info(imfile)
+  local w = info.width
+  local h = info.height
+  mytester:assert(w == img:size(3), 'image dimension error ')
+  mytester:assert(h == img:size(3), 'image dimension error ')
+  
+  -- Now load the raw binary from the source file into a ByteTensor
+  local fin = torch.DiskFile(imfile, 'r')
+  fin:binary()
+  fin:seekEnd()
+  local file_size_bytes = fin:position() - 1
+  fin:seek(1)
+  local img_binary = torch.ByteTensor(file_size_bytes)
+  fin:readByte(img_binary:storage())
+  fin:close()
+  
+  -- Now decompress the image from the ByteTensor
+  local img_from_tensor = image.decompressJPG(img_binary)
+  
+  mytester:assertlt((img_from_tensor - img):abs():max(), precision, 
+    'images from load and decompress dont match! ')
+end
+
+function test.LoadInvalid()
+  -- Make sure nothing nasty happens if we try and load a "garbage" tensor
+  local file_size_bytes = 1000
+  local img_binary = torch.rand(file_size_bytes):mul(255):byte()
+  
+  -- Now decompress the image from the ByteTensor
+  local img_from_tensor = image.decompressJPG(img_binary)
+  
+  mytester:assert(img_from_tensor == nil, 
+    'A non-nil was returned on an invalid input! ')
+end
+
+-- Now run the test above
+mytester:add(test)
+mytester:run()


### PR DESCRIPTION
This allows one to store JPEG images in memory and then decompress them when needed.  

This function is very nice for people doing imagenet.  If you downscale the imagenet detection 2014 images to 256x256 you can actually store the entire training set in memory as JPEGs (it's roughly 8GB depending on the compression quality) and then just decompress on the fly during training.  This means you don't have to take the hit of reading images to and from disk (which is especially egregious if you're storing the data on a NFS like I am).

Clearly the changes here are in a VERY, VERY important region of code.  Can one of the torch guys please do a thorough code review?  Let me know if you have any suggestions for changes OR if you want more tests added to the (admittedly simple) test script.  Luckily the changes to jpeg.c is pretty minor so I have high hopes that you guys will accept it as is.
