### PR TITLE
copy input before display to preserve the values

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -848,10 +848,8 @@ local function toDisplayTensor(...)
       for i,img in ipairs(input) do
          packed[i]:copy(input[i])
       end
-   elseif scaleeach then
-      packed = torch.Tensor(input:size()):copy(input)
    else
-      packed = input
+      packed = torch.Tensor(input:size()):copy(input)
    end
    
    -- scale each


### PR DESCRIPTION
without copy display changes value of inputs: 
 ```lua
require 'image'
fabio = image.fabio()
print(fabio:max())  -----> 0.9843137254902
image.display(fabio)
print(fabio:max())  -----> 1
image.display{ image=fabio, saturate=false, min = 0.5, max = 0.8}
print(fabio:max())  -----> 1.6666666666667
```