### PR TITLE
Add polar transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ Tensor `dst`.
 Rotates image `src` by `theta` radians. 
 If `dst` is specified it is used to store the results of the rotation.
 Variable `mode` specifies type of interpolation to be used. Valid values include 
-*simple*(the default) or *bilinear* interpolation.
+*simple* (the default) or *bilinear* interpolation.
 
 <a name="image.polar"/>
-### [res] image.polar([dst,], src, [mode]) ###
+### [res] image.polar([dst,], src, [interpolation], [mode]) ###
 Converts image `src` to polar coordinates. In the polar image, angular information is in the vertical direction and radius information in the horizontal direction.
-If `dst` is specified it is used to store the polar image. If `dst` is not specified, its size is automatically determined. Variable `mode` specifies type of interpolation to be used. Valid values include *simple*(the default) or *bilinear* interpolation.
+If `dst` is specified it is used to store the polar image. If `dst` is not specified, its size is automatically determined. Variable `interpolation` specifies type of interpolation to be used. Valid values include *simple* (the default) or *bilinear* interpolation. Variable `mode` determines whether the *full* image is converted to the polar space (implying empty regions in the polar image), or whether only the *valid* central part of the polar transform is returned (the default). 
 
 <a name="image.hflip"/>
 ### [res] image.hflip([dst,] src) ###

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ If `dst` is specified it is used to store the results of the rotation.
 Variable `mode` specifies type of interpolation to be used. Valid values include 
 *simple*(the default) or *bilinear* interpolation.
 
+<a name="image.polar"/>
+### [res] image.polar([dst,], src, [mode]) ###
+Converts image `src` to polar coordinates. In the polar image, angular information is in the vertical direction and radius information in the horizontal direction.
+If `dst` is specified it is used to store the polar image. If `dst` is not specified, its size is automatically determined. Variable `mode` specifies type of interpolation to be used. Valid values include *simple*(the default) or *bilinear* interpolation.
+
 <a name="image.hflip"/>
 ### [res] image.hflip([dst,] src) ###
 Flips image `src` horizontally (left<->right). If `dst` is provided, it is used to

--- a/generic/image.c
+++ b/generic/image.c
@@ -656,6 +656,232 @@ static int image_(Main_polarBilinear)(lua_State *L)
     return 0;
 }
 
+static int image_(Main_logPolar)(lua_State *L)
+{
+    THTensor *Tsrc = luaT_checkudata(L, 1, torch_Tensor);
+    THTensor *Tdst = luaT_checkudata(L, 2, torch_Tensor);
+    float doFull = luaL_checknumber(L, 3);
+    real *src, *dst;
+    long dst_stride0, dst_stride1, dst_stride2, dst_width, dst_height, dst_depth;
+    long src_stride0, src_stride1, src_stride2, src_width, src_height, src_depth;
+    long i, j, k;
+    float id, jd, a, r, m, midY, midX, fw;
+    long ii,jj;
+    
+    luaL_argcheck(L, Tsrc->nDimension==2 || Tsrc->nDimension==3, 1, "polar: src not 2 or 3 dimensional");
+    luaL_argcheck(L, Tdst->nDimension==2 || Tdst->nDimension==3, 2, "polar: dst not 2 or 3 dimensional");
+    
+    src= THTensor_(data)(Tsrc);
+    dst= THTensor_(data)(Tdst);
+    
+    dst_stride0 = 0;
+    dst_stride1 = Tdst->stride[Tdst->nDimension-2];
+    dst_stride2 = Tdst->stride[Tdst->nDimension-1];
+    dst_depth =  0;
+    dst_height = Tdst->size[Tdst->nDimension-2];
+    dst_width = Tdst->size[Tdst->nDimension-1];
+    if(Tdst->nDimension == 3) {
+        dst_stride0 = Tdst->stride[0];
+        dst_depth = Tdst->size[0];
+    }
+    
+    src_stride0 = 0;
+    src_stride1 = Tsrc->stride[Tsrc->nDimension-2];
+    src_stride2 = Tsrc->stride[Tsrc->nDimension-1];
+    src_depth =  0;
+    src_height = Tsrc->size[Tsrc->nDimension-2];
+    src_width = Tsrc->size[Tsrc->nDimension-1];
+    if(Tsrc->nDimension == 3) {
+        src_stride0 = Tsrc->stride[0];
+        src_depth = Tsrc->size[0];
+    }
+    
+    if( Tsrc->nDimension==3 && Tdst->nDimension==3 && ( src_depth!=dst_depth) ) {
+        luaL_error(L, "image.polar: src and dst depths do not match"); }
+    
+    if( (Tsrc->nDimension!=Tdst->nDimension) ) {
+        luaL_error(L, "image.polar: src and dst depths do not match"); }
+    
+    // compute maximum distance
+    midY = (float) src_height / 2.0;
+    midX = (float) src_width  / 2.0;
+    if(doFull == 1) {
+        m = sqrt((float) src_width * (float) src_width + (float) src_height * (float) src_height) / 2.0;
+    }
+    else {
+        m = (src_width < src_height) ? midX : midY;
+    }
+    
+    // loop to fill polar image
+    fw = (float) dst_width;
+    for(j = 0; j < dst_height; j++) {               // orientation loop
+        jd = (float) j;
+        a = (2 * M_PI * jd) / (float) dst_height;   // current angle
+        for(i = 0; i < dst_width; i++) {            // radius loop
+            float val = -1;
+            id = (float) i;
+            
+            r = m - m * (log(fw - id + 1.0) / log(fw));
+            
+            jj = (long) floor( r * cos(a) + midY);  // y-location in source image
+            ii = (long) floor(-r * sin(a) + midX);  // x-location in source image
+            
+            if(ii>src_width-1) val=0;
+            if(jj>src_height-1) val=0;
+            if(ii<0) val=0;
+            if(jj<0) val=0;
+            
+            if(Tsrc->nDimension==2)
+            {
+                if(val==-1)
+                    val=src[ii*src_stride2+jj*src_stride1];
+                dst[i*dst_stride2+j*dst_stride1] = val;
+            }
+            else
+            {
+                int do_copy=0; if(val==-1) do_copy=1;
+                for(k=0;k<src_depth;k++)
+                {
+                    if(do_copy)
+                        val=src[ii*src_stride2+jj*src_stride1+k*src_stride0];
+                    dst[i*dst_stride2+j*dst_stride1+k*dst_stride0] = val;
+                }
+            }
+        }
+    }
+    return 0;
+}
+static int image_(Main_logPolarBilinear)(lua_State *L)
+{
+    THTensor *Tsrc = luaT_checkudata(L, 1, torch_Tensor);
+    THTensor *Tdst = luaT_checkudata(L, 2, torch_Tensor);
+    float doFull = luaL_checknumber(L, 3);
+    real *src, *dst;
+    long dst_stride0, dst_stride1, dst_stride2, dst_width, dst_height, dst_depth;
+    long src_stride0, src_stride1, src_stride2, src_width, src_height, src_depth;
+    long i, j, k;
+    float id, jd, a, r, m, midY, midX, fw;
+    long ii_0, ii_1, jj_0, jj_1;
+    
+    luaL_argcheck(L, Tsrc->nDimension==2 || Tsrc->nDimension==3, 1, "polar: src not 2 or 3 dimensional");
+    luaL_argcheck(L, Tdst->nDimension==2 || Tdst->nDimension==3, 2, "polar: dst not 2 or 3 dimensional");
+    
+    src= THTensor_(data)(Tsrc);
+    dst= THTensor_(data)(Tdst);
+    
+    dst_stride0 = 0;
+    dst_stride1 = Tdst->stride[Tdst->nDimension-2];
+    dst_stride2 = Tdst->stride[Tdst->nDimension-1];
+    dst_depth =  0;
+    dst_height = Tdst->size[Tdst->nDimension-2];
+    dst_width = Tdst->size[Tdst->nDimension-1];
+    if(Tdst->nDimension == 3) {
+        dst_stride0 = Tdst->stride[0];
+        dst_depth = Tdst->size[0];
+    }
+    
+    src_stride0 = 0;
+    src_stride1 = Tsrc->stride[Tsrc->nDimension-2];
+    src_stride2 = Tsrc->stride[Tsrc->nDimension-1];
+    src_depth =  0;
+    src_height = Tsrc->size[Tsrc->nDimension-2];
+    src_width = Tsrc->size[Tsrc->nDimension-1];
+    if(Tsrc->nDimension == 3) {
+        src_stride0 = Tsrc->stride[0];
+        src_depth = Tsrc->size[0];
+    }
+    
+    if( Tsrc->nDimension==3 && Tdst->nDimension==3 && ( src_depth!=dst_depth) ) {
+        luaL_error(L, "image.polar: src and dst depths do not match"); }
+    
+    if( (Tsrc->nDimension!=Tdst->nDimension) ) {
+        luaL_error(L, "image.polar: src and dst depths do not match"); }
+    
+    // compute maximum distance
+    midY = (float) src_height / 2.0;
+    midX = (float) src_width  / 2.0;
+    if(doFull == 1) {
+        m = sqrt((float) src_width * (float) src_width + (float) src_height * (float) src_height) / 2.0;
+    }
+    else {
+        m = (src_width < src_height) ? midX : midY;
+    }
+    
+    // loop to fill polar image
+    fw = (float) dst_width;
+    for(j = 0; j < dst_height; j++) {                 // orientation loop
+        jd = (float) j;
+        a = (2 * M_PI * jd) / (float) dst_height;     // current angle
+        for(i = 0; i < dst_width; i++) {              // radius loop
+            float val = -1;
+            real ri, rj, wi, wj;
+            id = (float) i;
+            
+            r = m - m * (log(fw - id + 1.0) / log(fw));
+            
+            rj =  r * cos(a) + midY;                  // y-location in source image
+            ri = -r * sin(a) + midX;                  // x-location in source image
+            
+            ii_0=(long)floor(ri);
+            ii_1=ii_0 + 1;
+            jj_0=(long)floor(rj);
+            jj_1=jj_0 + 1;
+            wi = ri - ii_0;
+            wj = rj - jj_0;
+            
+            // switch to nearest interpolation when bilinear is impossible
+            if(ii_1>src_width-1 || jj_1>src_height-1 || ii_0<0 || jj_0<0) {
+                if(ii_0>src_width-1) val=0;
+                if(jj_0>src_height-1) val=0;
+                if(ii_0<0) val=0;
+                if(jj_0<0) val=0;
+                
+                if(Tsrc->nDimension==2)
+                {
+                    if(val==-1)
+                        val=src[ii_0*src_stride2+jj_0*src_stride1];
+                    dst[i*dst_stride2+j*dst_stride1] = val;
+                }
+                else
+                {
+                    int do_copy=0; if(val==-1) do_copy=1;
+                    for(k=0;k<src_depth;k++)
+                    {
+                        if(do_copy)
+                            val=src[ii_0*src_stride2+jj_0*src_stride1+k*src_stride0];
+                        dst[i*dst_stride2+j*dst_stride1+k*dst_stride0] = val;
+                    }
+                }
+            }
+            
+            // bilinear interpolation
+            else {
+                if(Tsrc->nDimension==2) {
+                    if(val==-1)
+                        val = (1.0 - wi) * (1.0 - wj) * src[ii_0*src_stride2+jj_0*src_stride1]
+                        + wi * (1.0 - wj) * src[ii_1*src_stride2+jj_0*src_stride1]
+                        + (1.0 - wi) * wj * src[ii_0*src_stride2+jj_1*src_stride1]
+                        + wi * wj * src[ii_1*src_stride2+jj_1*src_stride1];
+                    dst[i*dst_stride2+j*dst_stride1] = val;
+                } else {
+                    int do_copy=0; if(val==-1) do_copy=1;
+                    for(k=0;k<src_depth;k++) {
+                        if(do_copy) {
+                            val = (1.0 - wi) * (1.0 - wj) * src[ii_0*src_stride2+jj_0*src_stride1+k*src_stride0]
+                            + wi * (1.0 - wj) * src[ii_1*src_stride2+jj_0*src_stride1+k*src_stride0]
+                            + (1.0 - wi) * wj * src[ii_0*src_stride2+jj_1*src_stride1+k*src_stride0]
+                            + wi * wj * src[ii_1*src_stride2+jj_1*src_stride1+k*src_stride0];
+                        }
+                        dst[i*dst_stride2+j*dst_stride1+k*dst_stride0] = val;
+                    }
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+
 static int image_(Main_cropNoScale)(lua_State *L)
 {
   THTensor *Tsrc = luaT_checkudata(L, 1, torch_Tensor);
@@ -1440,6 +1666,8 @@ static const struct luaL_Reg image_(Main__) [] = {
   {"rotateBilinear", image_(Main_rotateBilinear)},
   {"polar", image_(Main_polar)},
   {"polarBilinear", image_(Main_polarBilinear)},
+  {"logPolar", image_(Main_logPolar)},
+  {"logPolarBilinear", image_(Main_logPolarBilinear)},
   {"translate", image_(Main_translate)},
   {"cropNoScale", image_(Main_cropNoScale)},
   {"warp", image_(Main_warp)},

--- a/init.lua
+++ b/init.lua
@@ -622,6 +622,80 @@ end
 rawset(image, 'polar', polar)
 
 ----------------------------------------------------------------------
+-- logpolar
+--
+local function logpolar(...)
+   local dst,src,interp,mode
+   local args = {...}
+   if select('#',...) == 4 then
+      dst    = args[1]
+      src    = args[2]
+      interp = args[3]
+      mode   = args[4]
+    elseif select('#',...) == 3 then
+      if type(args[2]) == 'string' then
+        src    = args[1]
+        interp = args[2]
+        mode   = args[3]
+      else        
+        dst    = args[1]
+        src    = args[2]
+        interp = args[3]
+      end
+   elseif select('#',...) == 2 then
+      if type(args[2]) == 'string' then
+        src    = args[1]
+        interp = args[2]
+      else
+        dst  = args[1]
+        src  = args[2]
+      end
+   elseif select('#',...) == 1 then
+     src = args[1]
+   else
+      print(dok.usage('image.logpolar',
+                       'convert an image to log-polar coordinates', nil,
+                       {type='torch.Tensor', help='input image', req=true},
+                       {type='string', help='interpolation: simple | bilinear', default='simple'},
+                       {type='string', help='mode: valid | full', default='valid'},
+                       '',
+                       {type='torch.Tensor', help='destination', req=true},
+                       {type='torch.Tensor', help='input image', req=true},
+                       {type='string', help='interpolation: simple | bilinear', default='simple'},
+                       {type='string', help='mode: valid | full', default='valid'}))
+      dok.error('incorrect arguments', 'image.polar')
+   end
+   interp = interp or 'valid'
+   mode = mode or 'simple'
+   if dst == nil then
+      local maxDist = math.floor(math.max(src:size(2), src:size(3)))
+      dst = src.new()
+      dst:resize(src:size(1), maxDist, maxDist)
+   end
+   if interp == 'simple' then
+      if mode == 'full' then
+        src.image.logpolar(src,dst,1)
+      elseif mode == 'valid' then
+        src.image.logpolar(src,dst,0)
+      else
+        dok.error('mode must be one of: valid | full', 'image.logpolar')
+      end
+   elseif interp == 'bilinear' then
+      if mode == 'full' then
+        src.image.logPolarBilinear(src,dst,1)
+      elseif mode == 'valid' then
+        src.image.logPolarBilinear(src,dst,0)
+      else
+        dok.error('mode must be one of: valid | full', 'image.logpolar')
+      end
+   else
+      dok.error('interpolation must be one of: simple | bilinear', 'image.logpolar')
+   end  
+   return dst  
+end
+rawset(image, 'logpolar', logpolar)
+
+----------------------------------------------------------------------
 -- warp
 --
 local function warp(...)

--- a/init.lua
+++ b/init.lua
@@ -674,9 +674,9 @@ local function logpolar(...)
    end
    if interp == 'simple' then
       if mode == 'full' then
-        src.image.logpolar(src,dst,1)
+        src.image.logPolar(src,dst,1)
       elseif mode == 'valid' then
-        src.image.logpolar(src,dst,0)
+        src.image.logPolar(src,dst,0)
       else
         dok.error('mode must be one of: valid | full', 'image.logpolar')
       end

--- a/init.lua
+++ b/init.lua
@@ -548,6 +548,54 @@ end
 rawset(image, 'rotate', rotate)
 
 ----------------------------------------------------------------------
+-- polar
+--
+local function polar(...)
+   local dst,src,mode
+   local args = {...}
+   if select('#',...) == 3 then
+      dst  = args[1]
+      src  = args[2]
+      mode = args[3]
+   elseif select('#',...) == 2 then
+      if type(args[2]) == 'string' then
+        src = args[1]
+        mode = args[2]
+      else
+        dst  = args[1]
+        src  = args[2]
+      end
+   elseif select('#',...) == 1 then
+     src = args[1]
+   else
+      print(dok.usage('image.polar',
+                       'convert an image to polar coordinates', nil,
+                       {type='torch.Tensor', help='input image', req=true},
+                       {type='string', help='mode: simple | bilinear', default='simple'},
+                       '',
+                       {type='torch.Tensor', help='destination', req=true},
+                       {type='torch.Tensor', help='input image', req=true},
+                       {type='string', help='mode: simple | bilinear', default='simple'}))
+      dok.error('incorrect arguments', 'image.polar')
+   end
+   mode = mode or 'simple'
+   if dst == nil then
+      local maxDist = math.floor(math.max(src:size(2), src:size(3)))
+      dst = src.new()
+      dst:resize(src:size(1), maxDist, maxDist)
+   end
+   if mode == 'simple' then
+      src.image.polar(src,dst)
+   elseif mode == 'bilinear' then
+      src.image.polarBilinear(src,dst)
+   else
+      dok.error('mode must be one of: simple | bilinear', 'image.polar')
+   end  
+   return dst  
+end
+rawset(image, 'polar', polar)
+
+----------------------------------------------------------------------
 -- warp
 --
 local function warp(...)


### PR DESCRIPTION
This PR adds image.polar() to perform a polar transform on an image. The code supports both nearest-neighbor and bilinear interpolation. I have also added a switch that allows for using transforming only the inner circle of the image, or transforming the full image (which implies the image is padded).