### PR TITLE
Revert "toDisplayTensor : input is only copied when necessary"

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -986,19 +986,19 @@ local function toDisplayTensor(...)
       {arg='saturate', type='boolean', help='saturate (useful when min/max are lower than actual min/max', default=true}
    )
 
-   local packed
+   local packed = torch.Tensor()
    if type(input) == 'table' then
       -- pack images in single tensor
       local ndims = input[1]:dim()
       local channels = ((ndims == 2) and 1) or input[1]:size(1)
       local height = input[1]:size(ndims-1)
       local width = input[1]:size(ndims)
-      packed = torch.Tensor(#input,channels,height,width)
+      packed:resize(#input,channels,height,width)
       for i,img in ipairs(input) do
          packed[i]:copy(input[i])
       end
    else
-      packed = torch.Tensor(input:size()):copy(input)
+      packed:resize(input:size()):copy(input)
    end
 
    -- scale each


### PR DESCRIPTION
This reverts commit 3bc649ac0258936dfc67e5de8320faed649b6bf8.
As discussed in issue #49.