### PR TITLE
Fix MSVC compilation.

### DIFF
--- a/generic/image.c
+++ b/generic/image.c
@@ -1600,7 +1600,7 @@ int image_(Main_warp)(lua_State *L) {
             long y_pix = floor(iy);
 
             // Precalculate the L(x) function evaluations in the u and v direction
-            const long rad = 3;  // This is a tunable parameter: 2 to 3 is OK
+            enum { rad = 3 };  // This is a tunable parameter: 2 to 3 is OK
             float Lu[2 * rad];  // L(x) for u direction
             float Lv[2 * rad];  // L(x) for v direction
             for (u=x_pix-rad+1, i=0; u<=x_pix+rad; u++, i++) {

--- a/png.c
+++ b/png.c
@@ -1,7 +1,6 @@
 
 #include <TH.h>
 #include <luaT.h>
-#include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Fix compilation under MSVC.
In "generic/image.c", MSVC does not currently support VLAs, and it doesn't recognize the array length "2*rad" is a constant. Change definition of "rad" to enum fixes this issue.
In "png.c", the unistd.h which is missing from MSVC seems to be unnecessary.

Tested compilation on MSVC 2013 Community with libjpeg-turbo-1.4.0 and libpng-1.6.16.
