### PR TITLE
image.gaussian result tensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ kernel of size `height x width`. When used as a Gaussian smoothing operator in a
 convolution, this kernel is used to `blur` images and remove detail and noise 
 (ref.: [Gaussian Smoothing](http://homepages.inf.ed.ac.uk/rbf/HIPR2/gsmooth.htm)).
 Optional arguments `[...]` expand to 
-`width`, `height`, `sigma_horz`, `sigma_vert`, `mean_horz`, `mean_vert`.
+`width`, `height`, `sigma_horz`, `sigma_vert`, `mean_horz`, `mean_vert` and `tensor`.
 
 The default value of `height` and `width` is `size`, where the latter 
 has a default value of 3. The amplitude of the Gaussian (its maximum value) 
@@ -388,12 +388,13 @@ corresponding means `mean_horz` and `mean_vert` are 0.5. Both the
 standard deviations and means are relative to kernels of unit width and height
 where the top-left corner is the origin. In other works, a mean of 0.5 is 
 the center of the kernel size, while a standard deviation of 0.25 is a quarter
-of it.
+of it. When `tensor` is provided (a 2D Tensor), the `height`, `width` and `size` are ignored.
+It is used to store the returned gaussian kernel.
 
 Note that arguments can also be specified as key-value arguments (in a table).
 
 <a name="image.gaussian1D"/>
-### [res] image.gaussian1D([size, sigma, amplitude, normalize, mean]) ###
+### [res] image.gaussian1D([size, sigma, amplitude, normalize, mean, tensor]) ###
 Returns a 1D Gaussian kernel of size `size`, mean `mean` and standard 
 deviation `sigma`. 
 Respectively, these arguments have default values of 3, 0.25 and 0.5. 
@@ -403,7 +404,9 @@ When `normalize=true`, the kernel is normalized to have a sum of 1.
 This overrides the `amplitude` argument. The default is `false`. Both the 
 standard deviation and mean are relative to a kernel of unit size. 
 In other works, a mean of 0.5 is the center of the kernel size, 
-while a standard deviation of 0.25 is a quarter of it.
+while a standard deviation of 0.25 is a quarter of it. 
+When `tensor` is provided (a 1D Tensor), the `size` is ignored.
+It is used to store the returned gaussian kernel.
 
 Note that arguments can also be specified as key-value arguments (in a table).
 

--- a/init.lua
+++ b/init.lua
@@ -1685,8 +1685,8 @@ end
 --
 function image.gaussian(...)
    -- process args
-   local _, size, sigma, amplitude, normalize,
-   width, height, sigma_horz, sigma_vert, mean_horz, mean_vert = dok.unpack(
+   local _, size, sigma, amplitude, normalize, width, height, 
+      sigma_horz, sigma_vert, mean_horz, mean_vert, tensor = dok.unpack(
       {...},
       'image.gaussian',
       'returns a 2D gaussian kernel',
@@ -1699,11 +1699,15 @@ function image.gaussian(...)
       {arg='sigma_horz', type='number', help='horizontal sigma', defaulta='sigma'},
       {arg='sigma_vert', type='number', help='vertical sigma', defaulta='sigma'},
       {arg='mean_horz', type='number', help='horizontal mean', default=0.5},
-      {arg='mean_vert', type='number', help='vertical mean', default=0.5}
+      {arg='mean_vert', type='number', help='vertical mean', default=0.5},
+      {arg='tensor', type='torch.Tensor', help='result tensor (height/width are ignored)'}
    )
-
+   if tensor then 
+      assert(tensor:dim() == 2, "expecting 2D tensor")
+      assert(tensor:nElement() > 0, "expecting non-empty tensor")
+   end
    -- generate kernel
-   local gauss = torch.Tensor(height, width)
+   local gauss = tensor or torch.Tensor(height, width)
    gauss.image.gaussian(gauss, amplitude, normalize, sigma_horz, sigma_vert, mean_horz, mean_vert)
 
    return gauss
@@ -1711,7 +1715,7 @@ end
 
 function image.gaussian1D(...)
    -- process args
-   local _, size, sigma, amplitude, normalize, mean
+   local _, size, sigma, amplitude, normalize, mean, tensor
       = dok.unpack(
       {...},
       'image.gaussian1D',
@@ -1720,14 +1724,20 @@ function image.gaussian1D(...)
       {arg='sigma', type='number', help='Sigma', default=0.25},
       {arg='amplitude', type='number', help='Amplitute of the gaussian (max value)', default=1},
       {arg='normalize', type='number', help='Normalize kernel (exc Amplitude)', default=false},
-      {arg='mean', type='number', help='Mean', default=0.5}
+      {arg='mean', type='number', help='Mean', default=0.5},
+      {arg='tensor', type='torch.Tensor', help='result tensor (size is ignored)'}
    )
 
    -- local vars
+   if tensor then
+      assert(tensor:dim() == 1, "expecting 1D tensor")
+      assert(tensor:nElement() > 0, "expecting non-empty tensor")
+      size = tensor:size(1)
+   end
    local center = mean * size + 0.5
 
    -- generate kernel
-   local gauss = torch.Tensor(size)
+   local gauss = tensor or torch.Tensor(size)
    for i=1,size do
       gauss[i] = amplitude * math.exp(-(math.pow((i-center)
                                               /(sigma*size),2)/2))


### PR DESCRIPTION
Allows for specifying a result tensor to image.gaussian and image.gaussian1D.