### PR TITLE
JPG and PNG: Aborts replaced with lua errors

### DIFF
--- a/generic/jpeg.c
+++ b/generic/jpeg.c
@@ -117,7 +117,7 @@ static int libjpeg_(Main_size)(lua_State *L)
      */
     jpeg_destroy_decompress(&cinfo);
     fclose(infile);
-    return 0;
+    luaL_error(L, "error reading JPEG object");
   }
 
   /* Now we can initialize the JPEG decompression object. */
@@ -230,7 +230,7 @@ static int libjpeg_(Main_load)(lua_State *L)
     if (infile) {
       fclose(infile);
     }
-    return 0;
+    luaL_error(L, "cannot open file for reading");
   }
   /* Now we can initialize the JPEG decompression object. */
   jpeg_create_decompress(&cinfo);
@@ -403,8 +403,7 @@ int libjpeg_(Main_save)(lua_State *L) {
   if (save_to_file == 1) {
     outfile = fopen( filename, "wb" );
     if ( !outfile ) {
-      printf("Error opening output jpeg file %s\n!", filename );
-      return -1;
+      luaL_error(L, "Error opening output jpeg file %s\n!", filename );
     }
   }
 

--- a/png.c
+++ b/png.c
@@ -9,16 +9,6 @@
 #define PNG_DEBUG 3
 #include <png.h>
 
-void abort_(const char * s, ...)
-{
-  va_list args;
-  va_start(args, s);
-  vfprintf(stderr, s, args);
-  fprintf(stderr, "\n");
-  va_end(args);
-  abort();
-}
-
 #define torch_(NAME) TH_CONCAT_3(torch_, Real, NAME)
 #define torch_Tensor TH_CONCAT_STRING_3(torch., Real, Tensor)
 #define libpng_(NAME) TH_CONCAT_3(libpng_, Real, NAME)


### PR DESCRIPTION
In the current codebase, exceptions in working with jpg or png images are often handled by program termination. The proposed change replaces those returns/aborts with lua errors. The advantage is that lua code can catch the exceptions by pcall() and react properly.