### PR TITLE
Added flip function (to a tensor up to 5D along an arbitrary dimension).

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ store the output image. Otherwise, returns a new `res` Tensor.
 Flips image `src` vertically (upsize<->down). If `dst` is provided, it is used to
 store the output image. Otherwise, returns a new `res` Tensor.
 
+<a name="image.flip"/>
+### [res] image.flip([dst,] src, flip_dim) ###
+Flips image `src` along the specified dimension. If `dst` is provided, it is used to
+store the output image. Otherwise, returns a new `res` Tensor.
+
 <a name="image.minmax"/>
 ### [res] image.minmax{tensor, [min, max, ...]} ###
 Compresses image `tensor` between `min` and `max`. 

--- a/test/test_flip.lua
+++ b/test/test_flip.lua
@@ -1,0 +1,62 @@
+require 'image'
+
+torch.setdefaulttensortype('torch.DoubleTensor')
+torch.setnumthreads(8)
+
+-- Create an instance of the test framework
+local precision = 1e-5
+local mytester = torch.Tester()
+local test = {}
+
+-- This is a correlated test (which is kinda lazy).  We're assuming HFLIP is OK.
+function test.FlipAgainstHFlip()
+  for ndims = 1, 5 do
+    for flip_dim = 1, ndims do
+      local sz = {}
+      for i = 1, ndims do
+        sz[i] = math.random(5,10)
+      end
+      
+      local input = torch.rand(unpack(sz))
+      local output = image.flip(input, flip_dim)
+      
+      -- Now perform the same operation using HFLIP
+      local input_tran = input
+      if (flip_dim < ndims) then
+        -- First permute the flip dimension to X dim
+        input_tran = input:transpose(flip_dim, ndims):contiguous()
+      end
+      -- Now reshape it to 3D
+      local original_hflip_sz = input_tran:size()
+      if ndims == 1 then
+        input_tran:resize(1, original_hflip_sz[1])
+      end
+      if ndims > 3 then
+        sz1 = 1
+        for i = 1, ndims - 2 do
+          sz1 = sz1 * original_hflip_sz[i]
+        end
+        input_tran:resize(sz1, original_hflip_sz[input_tran:dim()-1], 
+          original_hflip_sz[input_tran:dim()])
+      end
+     
+      local output_hflip = image.hflip(input_tran)
+      
+      -- Put it back to Ndim
+      output_hflip:resize(original_hflip_sz)
+      
+      if (flip_dim < ndims) then
+        -- permute bacx the flip dimension
+        output_hflip = output_hflip:transpose(flip_dim, ndims):contiguous()
+      end
+      
+      local err = output_hflip - output
+      mytester:asserteq(err:abs():max(), 0, 'error - bad flip! (ndims='..
+        ndims..',flip_dim='..flip_dim..')')
+    end
+  end
+end
+
+-- Now run the test above
+mytester:add(test)
+mytester:run()


### PR DESCRIPTION
The c function doesn't support in-place flips, but I check for this condition in the C code.  I'm using this for a scientific application, however you could also use it to swap RGB -> BGR which might be handy for some folks:

```lua
im = image.lena()
image.display(im)
image.display(image.flip(im, 1))  -- Swap R with B chan
```