### PR TITLE
modifed h/vflip assert to only check if 2D tensors are contiguous (maintaining backward compat.)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -812,8 +812,8 @@ local function hflip(...)
       dok.error('incorrect arguments', 'image.hflip')
    end
 
-   if not src:isContiguous() then
-     dok.error('input tensor is not contiguous', 'image.hflip')
+   if (src:dim() == 2) and (not src:isContiguous()) then
+     dok.error('2D input tensor is not contiguous', 'image.hflip')
    end
 
    dst = dst or src.new()
@@ -854,8 +854,8 @@ local function vflip(...)
       dok.error('incorrect arguments', 'image.vflip')
    end
 
-   if not src:isContiguous() then
-     dok.error('input tensor is not contiguous', 'image.vflip')
+   if (src:dim() == 2) and (not src:isContiguous()) then
+     dok.error('2D input tensor is not contiguous', 'image.vflip')
    end
 
    dst = dst or src.new()


### PR DESCRIPTION
Thanks to @Atcold for suggesting this.

This is a temporary fix.  It certainly can't go back to not having the assert but someone will need to fix it eventually.