### PR TITLE
image.gaussianpyramid non-default type input fix

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1954,18 +1954,18 @@ function image.gaussianpyramid(...)
    end
    if src:nDimension() == 2 then
       for i = 1,#scales do
-         dst[i] = dst[i] or torch.Tensor()
+         dst[i] = dst[i] or src.new()
          dst[i]:resize(src:size(1)*scales[i], src:size(2)*scales[i])
       end
    elseif src:nDimension() == 3 then
       for i = 1,#scales do
-         dst[i] = dst[i] or torch.Tensor()
+         dst[i] = dst[i] or src.new()
          dst[i]:resize(src:size(1), src:size(2)*scales[i], src:size(3)*scales[i])
       end
    else
       dok.error('src image must be 2D or 3D', 'image.gaussianpyramid')
    end
-   local k = image.gaussian{width=3, normalize=true}
+   local k = image.gaussian{width=3, normalize=true}:typeAs(src)
    local tmp = src
    for i = 1,#scales do
       if scales[i] == 1 then

--- a/test/test_gaussianpyramid.lua
+++ b/test/test_gaussianpyramid.lua
@@ -1,0 +1,25 @@
+require 'totem'
+require 'image'
+
+
+local tester = totem.Tester()
+
+
+local tests = {}
+
+function tests.doesNotCrash()
+  -- Char, Short and Int tensors not supported.
+  types = {
+      'torch.ByteTensor',
+      'torch.FloatTensor',
+      'torch.DoubleTensor'
+  }
+  for _, type in ipairs(types) do
+    local output = unpack(image.gaussianpyramid(torch.rand(8, 8):type(type), {0.5}))
+    tester:assert(output:type() == type, 'Type ' .. type .. ' produces a different output.')
+  end
+end
+
+
+return tester:add(tests):run()
+


### PR DESCRIPTION
Non-default tensor types as input to gaussian pyramid produce errors.

```lua
require 'image'
image.gaussianpyramid(torch.rand(8, 8), {0.5})  -- no error
image.gaussianpyramid(torch.rand(8, 8):float(), {0.5})  -- error
```