### PR TITLE
fix corner-case issues when rescaling

### DIFF
--- a/image-1.1.alpha-0.rockspec
+++ b/image-1.1.alpha-0.rockspec
@@ -19,7 +19,8 @@ using Torch's Tensor data structure.
 dependencies = {
    "torch >= 7.0",
    "sys >= 1.0",
-   "xlua >= 1.0"
+   "xlua >= 1.0",
+   "rational >= 1.0"
 }
 
 build = {

--- a/init.lua
+++ b/init.lua
@@ -35,6 +35,8 @@ require 'xlua'
 require 'dok'
 require 'libimage'
 
+local rational = require 'rational'
+
 ----------------------------------------------------------------------
 -- types lookups
 --
@@ -519,16 +521,18 @@ local function scale(...)
       local imax = math.max(iwidth,iheight)
       local omax = tonumber(size)
       if omax then
-         height = iheight / imax * omax
-         width = iwidth / imax * omax
+         local sc = rational(omax, imax)
+         height = (rational(iheight)*sc)()
+         width = (rational(iwidth)*sc)()
       else
          width,height = size:gfind('(%d*)x(%d*)')()
          if not width or not height then
             local imin = math.min(iwidth,iheight)
-            local omin = size:gfind('%^(%d*)')()
+            local omin = tonumber(size:gfind('%^(%d*)')())
             if omin then
-               height = iheight / imin * omin
-               width = iwidth / imin * omin
+               local sc = rational(omin, imin)
+               height = (rational(iheight)*sc)()
+               width = (rational(iwidth)*sc)()
             end
          end
       end


### PR DESCRIPTION
Using doubles when dealing with image sizes is risky.
Note that:

```lua
th> return  math.floor(100/161*161)
99
```

or:
```lua
th> = math.floor(113/100*100)
112
```

This leads to unexpected results in image.scale() such as:
```lua
th> return  image.scale(image.scale(image.lena(), 113, 100), "^100"):size()
   3
 100
 112
[torch.LongStorage of size 3]
```

or:
```lua
return  image.scale(image.scale(image.lena(), 161, 100), 161):size()
   3
  99
 161
[torch.LongStorage of size 3]
```

This PR addresses this issue by using rational numbers instead.
