### PR TITLE
Fix issues with ByteTensors.

### DIFF
--- a/image.c
+++ b/image.c
@@ -16,26 +16,6 @@
 #endif
 #define min( a, b ) ( ((a) < (b)) ? (a) : (b) )
 
-/*
- * Convert an sRGB color channel to a linear sRGB color channel.
- */
-static inline float gamma_expand_sRGB(float nonlinear)
-{
-  return (nonlinear <= 0.04045)
-          ? (nonlinear / 12.92)
-          : (pow((nonlinear+0.055)/1.055, 2.4));
-}
-
-/*
- * Convert a linear sRGB color channel to a sRGB color channel.
- */
-static inline float gamma_compress_sRGB(float linear)
-{
-  return (linear <= 0.0031308)
-          ? (12.92 * linear)
-          : (1.055 * pow(linear, 1.0/2.4) - 0.055);
-}
-
 #include "generic/image.c"
 #include "THGenerateAllTypes.h"
 

--- a/init.lua
+++ b/init.lua
@@ -1879,7 +1879,7 @@ function image.rgb2nrgb(...)
 end
 
 ----------------------------------------------------------------------
--- image.y2yet(image)
+-- image.y2jet(image)
 -- Converts a L-levels (1-L) greyscale image into a jet heat-map
 --
 function image.y2jet(...)
@@ -1896,9 +1896,6 @@ function image.y2jet(...)
       error('Invalid input for image.y2jet()')
    end
 
-   -- just use double
-   if torch.type(input) ~= 'torch.DoubleTensor' then input = input:double() end
-
    -- accept 3D grayscale
    if input:dim() == 3 and input:size(1) == 1 then
       input = input.new(input):resize(input:size(2), input:size(3))
@@ -1912,7 +1909,16 @@ function image.y2jet(...)
    local output = output or input.new()
    local L = input:max()
 
-   local colorMap = image.jetColormap(L):typeAs(input)
+   local colorMap = image.jetColormap(L)
+   if torch.type(input) == 'torch.ByteTensor' then
+     colorMap = colorMap:mul(255):round()
+     colorMap[torch.lt(colorMap, 0)] = 0
+     colorMap[torch.gt(colorMap, 255)] = 255
+     colorMap = colorMap:byte()
+   else
+     colorMap = colorMap:typeAs(input)
+   end
+
    input.image.colorize(output, input-1, colorMap)
 
    return output


### PR DESCRIPTION
Summary
=======

In generic/image.c many of the intermediate calculations are done using the
datatype `real`. For `ByteTensor`s this is an integral type meaning that undesired
results are obtained for `ByteTensor`s.

The following methods are fixed for ByteTensors:
*   y2jet
*   rgb2y
*   rgb2hsv
*   hsv2rgb
*   rgb2hsl
*   hsl2rgb
*   gaussian

The following methods are disabled for ByteTensors:
*   rgb2lab
*   lab2rgb

The following methods are believed to be fixed for ByteTensors, but have not
been tested:
*   warp
*   rotate
*   polar

The following methods have not been functionally modified, are believed to
already work for ByteTensors, but have not been tested:
*   crop
*   translate
*   vflip
*   hflip
*   flip

Changes
=======

generic/image.c
---------------
*   Define a `temp_t` type to control the precision of intermediate
    calculations. This avoids hard-wiring 64-bit precision for 32-bit
    calculations.
*   Use `temp_t` in place of `real` for intermediate variables. If the function
    already uses `float` for intermediate calculations then continue to use
    `float`.
*   Rename `image_(FromDouble)` to `image_(FromIntermediate)`.
*   Use `image_(FromIntermediate)` wherever assigning a non-`real` to a `real`.
    For ByteTensors, this ensures rounding and clipping to the range [0, 255].
*   For color conversion, use the ranges [0, 255] rather than [0, 1] for
    ByteTensors.
*   Remove `rgb2lab` and `lab2rgb` for ByteTensors. Lab is not constrained to
    [0, 1] and does not fit well into a 1 byte quantization depth. It makes no
    sense to have this for ByteTensors.
*   Make `saturate` a noop for ByteTensors, since they are already constrained
    to [0, 255].
*   In `colorize` randomize a color value only if the colormap has not been set.
    There was a bug that meant that for ByteTensors any color with R=255 would
    be randomized.

test/test.lua
-------------
*   Add gaussian test cases.
*   Modify `bilinearUpscale_ByteTensor` test to reflect change to rounding
    behavior.
*   Update test cases so all color conversion functions are covered.

init.lua
--------
*   Allow `y2jet` to operate on `FloatTensor`s and `ByteTensor`s.

image.c
-------
*   Move sRGB conversion functions to `generic/image.c`.