### PR TITLE
Only scale output in image.crop if dst is provded

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -473,8 +473,11 @@ local function crop(...)
          x = src.new(endy-starty,endx-startx)
       end
       src.image.cropNoScale(src,x,startx,starty)
-      dst = dst or src.new():resizeAs(x)
-      image.scale(dst,x)
+      if dst then
+         image.scale(dst, x)
+      else
+         dst = x
+      end
    end
    return dst
 end


### PR DESCRIPTION
This speeds up calls to image.crop that don't pass a dst image