### PR TITLE
ppm: raise an error if fopen failed

### DIFF
--- a/generic/ppm.c
+++ b/generic/ppm.c
@@ -7,7 +7,7 @@ static int libppm_(Main_load)(lua_State *L)
   const char *filename = luaL_checkstring(L, 1);
   FILE* fp = fopen ( filename, "r" );
   if ( !fp ) {
-    printf ( "Failed to open file '%s'!\n", filename );
+    luaL_error(L, "cannot open file <%s> for reading", filename);
   }
 
   long W,H,C;
@@ -144,7 +144,7 @@ int libppm_(Main_save)(lua_State *L) {
   // open file
   FILE* fp = fopen(filename, "w");
   if ( !fp ) {
-    luaL_error(L, "cannot open file <%s> for reading", filename);
+    luaL_error(L, "cannot open file <%s> for writing", filename);
   }
 
   // write 3 or 1 channel(s) header


### PR DESCRIPTION
Apart from this minor PR, note that I faced this problem while re-installing and running tests (that failed / seg. faulted because of missing assets). LuaRocks install logs indicated that:

```
-- Installing: /path/to/torch/install/lib/luarocks/rocks/image/1.1.alpha-0/lua/image/assets/lena.jpg
[...]
Warning: /path/to/torch/install/share/lua/5.1/image/assets/lena.jpg is not tracked by this installation of LuaRocks. Moving it to /path/to/torch/install/share/lua/5.1/image/assets/lena.jpg~~~
```

First time ever I encountered this. Plus: it sounds like there is a race or something because it is not reproducible.

So the question is: is it the right way to do to install asset files on behalf of LuaRocks like [here](https://github.com/torch/image/blob/0013b8c4ac71eda9793159caddb906d6f495482b/CMakeLists.txt#L76)? (apparently not)

I thought about using `copy_directories`:

```Lua
build = {
   type = "command",
   -- ...
   copy_directories = { "assets" }
}
```

But then the assets are in a non standard location - see this discussion on this topic: https://github.com/keplerproject/luarocks/issues/168

What do you guys think would be the right solution?