### PR TITLE
Fix bicubic interpolation when source has size 1

### DIFF
--- a/generic/image.c
+++ b/generic/image.c
@@ -166,6 +166,12 @@ static void image_(Main_scaleCubic_rowcol)(THTensor *Tsrc,
     long i;
     for( i = 0; i < dst_len; i++ )
       dst[ dst_start + i*dst_stride ] = src[ src_start + i*src_stride ];
+  } else if ( src_len == 1 ) {
+     long i;
+     for( i = 0; i < dst_len - 1; i++ ) {
+       long dst_pos = dst_start + i*dst_stride;
+       dst[dst_pos] = src[ src_start ];
+     }
   } else {
     long di;
     float si_f;


### PR DESCRIPTION
The bicubic interpolation code accesses non-allocated memory when `src_len` is 1 because it doesn't have a special case like bilinear interpolation does. This PR addresses that bug.

I ran the following test to confirm it works:
```
require 'image'
im = torch.randn(3, 2, 3):float()
for n = 1,1000 do resim = image.scale(im, 256, 768, 'bicubic') end
```