### PR TITLE
Fix in image.scale when one of the dimensions is too small

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -648,6 +648,8 @@ local function scale(...)
       dok.error('could not find valid dest size', 'image.scale')
    end
    if not dst then
+      height = math.max(height, 1)
+      width = math.max(width, 1)
       if src:nDimension() == 3 then
          dst = src.new(src:size(1), height, width)
       else


### PR DESCRIPTION
If height or width is less than one after the resize, the output tensor would have the wrong number dimensions (2 or 1 instead of 3).
Before:
```lua
image.scale(torch.rand(3,3,600),100):size()
-- the output is a tensor of size 3
```
After
```lua
image.scale(torch.rand(3,3,600),100):size()
-- the output is a tensor of size 3x1x100
```