### PR TITLE
Fixes for test_warp.lua

### DIFF
--- a/test/test_rotate.lua
+++ b/test/test_rotate.lua
@@ -12,50 +12,50 @@ local function test_rotate(src, mode)
       
       -- rotate
       if mode then
-	 d1 = image.rotate(src, theta, mode)
-	 d2 = src.new():resizeAs(src)
-	 image.rotate(d2, src, theta, mode)
+         d1 = image.rotate(src, theta, mode)
+         d2 = src.new():resizeAs(src)
+         image.rotate(d2, src, theta, mode)
       else
-	 d1 = image.rotate(src, theta)
-	 d2 = src.new():resizeAs(src)
-	 image.rotate(d2, src, theta)
+         d1 = image.rotate(src, theta)
+         d2 = src.new():resizeAs(src)
+         image.rotate(d2, src, theta)
       end
+
       -- revert
       local revert = 2 * math.pi - theta
       if mode then
-	 d3 = image.rotate(d1, revert, mode)
-	 d4 = src.new():resizeAs(src)
-	 image.rotate(d4, d2, revert, mode)
+         d3 = image.rotate(d1, revert, mode)
+         d4 = src.new():resizeAs(src)
+         image.rotate(d4, d2, revert, mode)
       else
-	 d3 = image.rotate(d1, revert)
-	 d4 = src.new():resizeAs(src)
-	 image.rotate(d4, d2, revert)
+         d3 = image.rotate(d1, revert)
+         d4 = src.new():resizeAs(src)
+         image.rotate(d4, d2, revert)
       end
       
       -- diff
       if src:dim() == 3 then
-	 local cs = image.crop(src, src:size(2) / 4, src:size(3) / 4, src:size(2) / 4 * 3, src:size(3) / 4 * 3)
-	 local c3 = image.crop(d3, src:size(2) / 4, src:size(3) / 4, src:size(2) / 4 * 3, src:size(3) / 4 * 3)
-	 local c4 = image.crop(d4, src:size(2) / 4, src:size(3) / 4, src:size(2) / 4 * 3, src:size(3) / 4 * 3)
-      
-	 mean_dist = mean_dist + cs:dist(c3)
-	 mean_dist = mean_dist + cs:dist(c4)
+         local cs = image.crop(src, src:size(2) / 4, src:size(3) / 4, src:size(2) / 4 * 3, src:size(3) / 4 * 3)
+         local c3 = image.crop(d3, src:size(2) / 4, src:size(3) / 4, src:size(2) / 4 * 3, src:size(3) / 4 * 3)
+         local c4 = image.crop(d4, src:size(2) / 4, src:size(3) / 4, src:size(2) / 4 * 3, src:size(3) / 4 * 3)
+         mean_dist = mean_dist + cs:dist(c3)
+         mean_dist = mean_dist + cs:dist(c4)
       elseif src:dim() == 2 then
-	 local cs = image.crop(src, src:size(1) / 4, src:size(2) / 4, src:size(1) / 4 * 3, src:size(2) / 4 * 3)
-	 local c3 = image.crop(d3, src:size(1) / 4, src:size(2) / 4, src:size(1) / 4 * 3, src:size(2) / 4 * 3)
-	 local c4 = image.crop(d4, src:size(1) / 4, src:size(2) / 4, src:size(1) / 4 * 3, src:size(2) / 4 * 3)
-	 mean_dist = mean_dist + cs:dist(c3)
-	 mean_dist = mean_dist + cs:dist(c4)
+         local cs = image.crop(src, src:size(1) / 4, src:size(2) / 4, src:size(1) / 4 * 3, src:size(2) / 4 * 3)
+         local c3 = image.crop(d3, src:size(1) / 4, src:size(2) / 4, src:size(1) / 4 * 3, src:size(2) / 4 * 3)
+         local c4 = image.crop(d4, src:size(1) / 4, src:size(2) / 4, src:size(1) / 4 * 3, src:size(2) / 4 * 3)
+         mean_dist = mean_dist + cs:dist(c3)
+         mean_dist = mean_dist + cs:dist(c4)
       end
+      --[[
       if i == 1 then
-	 --[[
-	 image.display(src)
-	 image.display(d1)
-	 image.display(d2)
-	 image.display(d3)
-	 image.display(d4)
-	 --]]
+         image.display(src)
+         image.display(d1)
+         image.display(d2)
+         image.display(d3)
+         image.display(d4)
       end
+      --]]
    end
    if mode then
       print("mode = " .. mode .. ", mean dist: " .. mean_dist / (10 * 2))

--- a/test/test_warp.lua
+++ b/test/test_warp.lua
@@ -32,8 +32,8 @@ flow_scale[1] = grid_y
 flow_scale[2] = grid_x
 flow_scale[1]:add(1):mul(0.5) -- 0 to 1
 flow_scale[2]:add(1):mul(0.5) -- 0 to 1
-flow_scale[1]:mul(height)
-flow_scale[2]:mul(width)
+flow_scale[1]:mul(height-1)
+flow_scale[2]:mul(width-1)
 flow:add(flow_scale)
 
 t0 = sys.clock()
@@ -86,8 +86,8 @@ flow_scale[1] = grid_y
 flow_scale[2] = grid_x
 flow_scale[1]:add(1):mul(0.5) -- 0 to 1
 flow_scale[2]:add(1):mul(0.5) -- 0 to 1
-flow_scale[1]:mul(height)
-flow_scale[2]:mul(width)
+flow_scale[1]:mul(height-1)
+flow_scale[2]:mul(width-1)
 flow:add(flow_scale)
 
 flow_rot = torch.FloatTensor()


### PR DESCRIPTION
Hi, two commits
(1) Fixes the test_warp scaling bug
(2) Fixes indentation in the rotation test script (that i verifies works correctly).

There is a mistake in `test_warp.lua`. Try a rotation of 0 degrees and you will see that it will scale ever slightly, by around one pixel. The following thing describes the problem and shows the fix of the PR:
### Current:
![current_test_warp](https://cloud.githubusercontent.com/assets/7721540/15585970/3ec41a32-2382-11e6-9f38-d5edd633665b.gif)
### PR:
![pr_test_warp](https://cloud.githubusercontent.com/assets/7721540/15585973/434ac6dc-2382-11e6-9772-7dbcf78b4d70.gif)

_Do not look at the colors themselves, the .GIF format might have changed them._
Look how in the current state the geometry changes with respect to the source image. And look how the geometry stays exactly on-pixel.
Luckily little harm is done as this is a test script, but this is the real only documentation that is to be found about the warp functionality, it's good to keep it correctly. I found this bug because I was implementing the warp functionality and found the way that it was used here to be erroneous.
Great package! Keep it up. 