### PR TITLE
Add details about image saving in the doc

### DIFF
--- a/doc/saveload.md
+++ b/doc/saveload.md
@@ -35,6 +35,7 @@ local img = image.load(imagefile,1,'byte')
 Saves Tensor `tensor` to disk at path `filename`. The format to which 
 the image is saved is extrapolated from the `filename`'s extension suffix.
 The `tensor` should be of size `nChannel x height x width`.
+To save with a minimal loss, the tensor values should lie in the range [0, 1] since the tensor is clamped between 0 and 1 before being saved to the disk.
 
 <a name="image.decompressJPG"></a>
 ### [res] image.decompressJPG(tensor, [depth, tensortype]) ###


### PR DESCRIPTION
Here is a small precision about image saving.

In image.save, the tensor is first clamped between 0 and 1 before being written to the disk.
This can lead to unexpected behaviors (this was not mentioned in the doc yet) when one saves a image tensor whose values are outside this range (for instance a centered/normalized preprocessed image). See the example below :  

![saving](https://cloud.githubusercontent.com/assets/7393801/16560066/5961a688-41f1-11e6-8f96-75ff24fa08a6.png)

A solution could be to scale the tensor between 0 and 255 directly instead of clamping/scaling. 
But as this may have been done on purpose (?), and as it may cause backward-compatibility issues, I simply propose here to clarify this in the doc.
