### PR TITLE
Global y1

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -470,7 +470,7 @@ local function crop(...)
       else
          iwidth,iheight = src:size(2),src:size(1)
       end
-      local x1, x2
+      local x1, y1
       if format == 'c' then
          x1, y1 = math.floor((iwidth-width)/2), math.floor((iheight-height)/2)
       elseif format == 'tl' then


### PR DESCRIPTION
I BELIEVE y1 is being created globally in the crop function, and that x2 is not actually being used. So, I've changed local x1, x2 to local x1, y1. See: https://github.com/torch/image/issues/177

So, I was tracking down where y1 was getting defined in my programs, and I believe it's actually not in my program, it's in image/init.lua... (I'm not really sure tho..)

So, in init.lua in crop I see

````
elseif format == 'tl' then
   x1, y1 = 0,0
````

It's actually all throughout all those cases. My suspicion is that "x2" was meant to be "y1", given that I don't see x2 being used anywhere else in there. In any case, here's how I replicate the problem:

```
require "image"

assert(_G["y1"] == nil)
tt = torch.randn(3,256,256)
cropped = image.crop(tt, "c", 224, 224)
assert(_G["y1"] == nil, "Where was y1 defined??")
```