### PR TITLE
Fixes warp type-cast issue in #189

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -954,7 +954,6 @@ local function warp(...)
       dok.error('Incorrect arguments (clamp_mode is not clamp | pad)!', 'image.warp')
    end
 
-   local field = field:typeAs(torch.Tensor()) -- coerce matrix to default tensor type
    local dim2 = false
    if src:nDimension() == 2 then
       dim2 = true

--- a/test/test_warp.lua
+++ b/test/test_warp.lua
@@ -137,3 +137,10 @@ image.display{image = im_lanczos, zoom = 4, legend = 'rotation lanczos (pad 1)'}
 
 image.display{image = im, zoom = 4, legend = 'source image'}
 
+-- ***********************************************
+-- NOW MAKE SURE BOTH FLOAT AND DOUBLE INPUTS WORK
+-- ***********************************************
+
+mtx = torch.zeros(2, 32, 32)
+out = image.warp(im:float(), mtx:float(), 'bilinear')
+out = image.warp(im:double(), mtx:double(), 'bilinear')


### PR DESCRIPTION
PR #189 introduced fixing of the `field` variable to that of the torch's default type.
If it should have been casted at all, it should be casted to that of the image's input type, to circumvent the type-similarity issue not being thrown.
I have decided to remove this cast introduced in #189 altogether, making it the developers responsibility to cast and use correct and matching types.
I have also added a few lines of tests in `test_warp.lua` to make sure this issue does not re-occur:
```lua
out = image.warp(im:float(), mtx:float(), 'bilinear') -- both float
out = image.warp(im:double(), mtx:double(), 'bilinear') --both double
```
And do note mixing will throw a proper error
```lua
out = image.warp(im:float(), mtx:double(), 'bilinear') -- fails with crystal clear type error
out = image.warp(im:double(), mtx:float(), 'bilinear') -- fails with crystal clear type error
```
Closes https://github.com/NVIDIA/DIGITS/issues/1134