### PR TITLE
Fix out-of-boundary bug when lineWidth is big

### DIFF
--- a/generic/image.c
+++ b/generic/image.c
@@ -2227,27 +2227,30 @@ int image_(Main_drawRect)(lua_State *L) {
   int cg = luaL_checkint(L, 8);
   int cb = luaL_checkint(L, 9);
 
-  int offset = lineWidth / 2;
-  int x1 = (int) MAX(0, x1long - offset - 1);
-  int y1 = (int) MAX(0, y1long - offset - 1);
-  int x2 = (int) MIN(output->size[2] - 1, x2long - offset - 1);
-  int y2 = (int) MIN(output->size[1] - 1, y2long - offset - 1);
+  int loffset = lineWidth / 2 + 1;
+  int uoffset = lineWidth - loffset - 1;
+  int x1l = (int) MAX(0, x1long - loffset);
+  int y1l = (int) MAX(0, y1long - loffset);
+  int x1u = (int) MIN(output->size[2], x1long + uoffset + 1);
+  int y1u = (int) MIN(output->size[1], y1long + uoffset + 1);
+  int x2l = (int) MAX(0, x2long - loffset);
+  int y2l = (int) MAX(0, y2long - loffset);
+  int x2u = (int) MIN(output->size[2], x2long + uoffset + 1);
+  int y2u = (int) MIN(output->size[1], y2long + uoffset + 1);
 
-  int w = x2 - x1 + 1;
-  int h = y2 - y1 + 1;
-  for (int y = y1; y < y2 + lineWidth; y++) {
-    for (int x = x1; x < x1 + lineWidth; x++) {
+  for (int y = y1l; y < y2u; y++) {
+    for (int x = x1l; x < x1u; x++) {
       image_(drawPixel)(output, y, x, cr, cg, cb);
     }
-    for (int x = x2; x < x2 + lineWidth; x++) {
+    for (int x = x2l; x < x2u; x++) {
       image_(drawPixel)(output, y, x, cr, cg, cb);
     }
   }
-  for (int x = x1; x < x2 + lineWidth; x++) {
-    for (int y = y1; y < y1 + lineWidth; y++) {
+  for (int x = x1l; x < x2u; x++) {
+    for (int y = y1l; y < y1u; y++) {
       image_(drawPixel)(output, y, x, cr, cg, cb);
     }
-    for (int y = y2; y < y2 + lineWidth; y++) {
+    for (int y = y2l; y < y2u; y++) {
       image_(drawPixel)(output, y, x, cr, cg, cb);
     }
   }


### PR DESCRIPTION
 `drawRect` throws error when `lineWidth>1` and a pixel coordinate of the rectangle is out of the image boundary. e.g., the following code could not succeed
```
image = require 'image'
bg = torch.ByteTensor(3, 100, 100):fill(3)
img = image.drawRect(bg, 0, 80, 50, 99, {color={255, 0, 255}, lineWidth=5})
image.save('test.png', img)
```
which throws error:
```
/scratch0/torch/install/share/lua/5.1/image/init.lua:2172: bad argument #2 to 'drawRect' (out of range at /tmp/luarocks_torch-scm-1-3526/torch7/lib/TH/generic/THTensor.c:759)
stack traceback:
	[C]: at 0x7f9ca8b008e0
	[C]: in function 'drawRect'
	/scratch0/torch/install/share/lua/5.1/image/init.lua:2172: in function 'drawRect'
	/scratch0/image/test.lua:3: in main chunk
```

After this fix, the same code could generate rectangles on top of the image with ignored pixels on the line and out of the image boundary.
![test](https://cloud.githubusercontent.com/assets/3343650/22094089/beb79c12-ddd8-11e6-8923-be182526c622.png)