### PR TITLE
compressPNG should require 'liblua_png' rather than 'libpng'.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -205,7 +205,7 @@ function image.getPNGsize(filename)
 end
 
 local function compressPNG(tensor)
-   if not xlua.require 'libpng' then
+   if not xlua.require 'liblua_png' then
       dok.error('libpng package not found, please install libpng',
          'image.compressPNG')
    end


### PR DESCRIPTION
All other PNG calls require 'liblua_png' and the test currently
fails on compression.