### PR TITLE
Fix image channel convertion

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -72,9 +72,9 @@ end
 local function todepth(img, depth)
    if depth and depth == 1 then
       if img:nDimension() == 2 then
-         -- all good
+         img = img:view(1, img:size(1), img:size(2))
       elseif img:size(1) == 3 or img:size(1) == 4 then
-	 img = image.rgb2y(img:narrow(1,1,3))[1]
+         img = image.rgb2y(img:narrow(1,1,3))
       elseif img:size(1) == 2 then
          img = img:narrow(1,1,1)
       elseif img:size(1) ~= 1 then

--- a/test/test.lua
+++ b/test/test.lua
@@ -263,7 +263,7 @@ function flip_tests.test_transformation_largeByteImage(flip)
     local x_real = image.fabio():double():mul(255)
     local x_byte = x_real:clone():byte()
 
-    assert(x_byte:size(1) > 256 and x_byte:size(2) > 256, 'Tricky case only occurs for images larger than 256 px, pick another example')
+    assert(x_byte:size(2) > 256 and x_byte:size(3) > 256, 'Tricky case only occurs for images larger than 256 px, pick another example')
 
     local f_real, f_byte
     f_real = image[flip](x_real)


### PR DESCRIPTION
Make sure `image.load` always return a 3D tensor, so that users do not need to worry about the tensor shape.